### PR TITLE
Add Submission API to Validators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,12 @@ DATABASE_POOL_SIZE=5             # Default
 DATABASE_MAX_OVERFLOW=10         # Default
 DATABASE_POOL_TIMEOUT=30         # Default (seconds)
 DATABASE_ECHO=True               # Set to True for debugging
+
+# Submission server, setup this to get direct submissions from miners and gossip from other validators
+# REQUIRED: Public Network Identity (for peer connections)
+# SUBMISSION_SERVER_PUBLIC_IP=""    # Public IP (get from cloud provider)
+# SUBMISSION_SERVER_EXTERNAL_PORT=10000  # Public-facing port (required)
+
+# Server Binding Configuration
+SUBMISSION_SERVER_HOST="0.0.0.0"  # Bind to all interfaces (default)
+# SUBMISSION_SERVER_PORT=10000      # Internal listening port (required)

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ The validator implements this incentive mechanism through several key steps:
 
 2. **Content Discovery**: Validators query on-chain commits to retrieve miners' X accounts. They then discover new posts made by miners, filtering them through Large Language Models (LLM) to ensure the content is nuanced and relevant to specific subjects, such as bittensor.
 
-3. **Interaction Analysis**: Validators identify interactions with miners' posts, filtering them for positivity and ensuring they originate from a list of verified users.
+3. **Direct Submission (New)**: Miners can now submit their posts and interactions directly to validators via API, enabling faster content processing and reducing the load on validators' discovery systems.
 
-4. **Scoring**: Interactions are scored based on multiple factors:
+4. **Interaction Analysis**: Validators identify interactions with miners' posts, filtering them for positivity and ensuring they originate from a list of verified users.
+
+5. **Scoring**: Interactions are scored based on multiple factors:
    - **Interaction Type**: Replies is the only supported interaction type at the moment
    - **Recency**: Only interactions within the last 14 days are considered, with newer interactions weighted higher
    - **Account Influence**: Higher scores for interactions from accounts with more followers
    - **Content Categories**: Scores are weighted by topic categories, allowing emphasis on specific subjects
 
-5. **Score Aggregation**: Final scores are calculated by:
+6. **Score Aggregation**: Final scores are calculated by:
    - Normalizing scores within each category
    - Applying category weights to prioritize certain topics
    - Setting weights on the Bittensor chain to determine miner rewards

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -15,6 +15,14 @@ Below is the minimum system requirements for running a validator node on the Nua
 - 16-GB RAM
 - 512-GB Storage
 
+## Network Requirements
+
+Validators now require a publicly accessible submission server for receiving direct submissions from miners:
+
+- **Public IP Address**: Required for peer-to-peer communication
+- **Open Port**: Default 10000 (configurable)
+- **Firewall Rules**: Allow inbound TCP connections on your submission server port
+
 ## Setup Instructions
 To set up a validator node on the Nuance Subnet, follow these steps:
 
@@ -105,6 +113,10 @@ To set up a validator node on the Nuance Subnet, follow these steps:
     
     # Database configuration
     DATABASE_URL=sqlite+aiosqlite:///./nuance.db
+    
+    # Submission Server Configuration (REQUIRED)
+    SUBMISSION_SERVER_PUBLIC_IP=your.public.ip.address    # Get from your cloud provider
+    SUBMISSION_SERVER_EXTERNAL_PORT=10000                 # Port accessible from internet
     ```
 
     The `.env` file supports many configuration options:
@@ -131,9 +143,27 @@ To set up a validator node on the Nuance Subnet, follow these steps:
     DATABASE_MAX_OVERFLOW=10
     DATABASE_POOL_TIMEOUT=30
     DATABASE_ECHO=False
+    
+    # Submission Server Configuration
+    SUBMISSION_SERVER_PUBLIC_IP=your.public.ip.address    # REQUIRED: Your public IP
+    SUBMISSION_SERVER_EXTERNAL_PORT=10000                 # REQUIRED: Public port
+    SUBMISSION_SERVER_HOST=0.0.0.0                       # Interface to bind (default: all)
+    SUBMISSION_SERVER_PORT=10000                         # Internal port (default: 10000)
     ```
 
-5. Start the validator node
+5. Configure Firewall
+
+   Ensure your submission server port is accessible:
+   ```sh
+   # Example for UFW firewall
+   sudo ufw allow 10000/tcp
+   sudo ufw reload
+   
+   # Verify the port is open
+   sudo ufw status
+   ```
+
+6. Start the validator node
 
    Before starting the validator, ensure your wallet is registered on the subnet:
    ```sh
@@ -179,3 +209,23 @@ To set up a validator node on the Nuance Subnet, follow these steps:
    3. Start the validator with PM2
 
    The validator will read all configuration from your `.env` file, so you don't need to pass any parameters as command-line arguments.
+
+## Troubleshooting
+
+If miners cannot connect to your submission server:
+
+1. Verify your public IP is correct (Caution: We test this with Tensordock, so the IP from this command may not be accurate):
+   ```sh
+   curl ifconfig.me
+   ```
+
+2. Check if the port is accessible from outside, using external port:
+   ```sh
+   nc -zv your.public.ip.address 10000
+   ```
+
+3. Ensure no NAT/firewall is blocking the connection
+4. Check validator logs for any errors:
+   ```sh
+   pm2 logs validator_sn23 --lines 100
+   ```

--- a/examples/miner_submit.ipynb
+++ b/examples/miner_submit.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Miner can submit to validators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install bittensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import json\n",
+    "import time\n",
+    "from hashlib import sha256\n",
+    "from uuid import uuid4\n",
+    "from math import ceil\n",
+    "from typing import Any, Optional\n",
+    "\n",
+    "import bittensor as bt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wallet_name = \"default\"\n",
+    "wallet_hotkey = \"default\"\n",
+    "\n",
+    "platform = \"twitter\"\n",
+    "verification_post_id = \"123\"\n",
+    "account_id = \"123\"\n",
+    "username = \"123\"\n",
+    "post_id = \"123\"\n",
+    "interaction_id = \"123\"\n",
+    "\n",
+    "data = {\n",
+    "    \"platform\": platform,\n",
+    "    \"account_id\": account_id,\n",
+    "    \"username\": username,\n",
+    "    \"verification_post_id\": verification_post_id,\n",
+    "    \"post_id\": post_id,\n",
+    "    \"interaction_id\": interaction_id,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metagraph = bt.metagraph(23)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_axons = metagraph.axons\n",
+    "all_validator_axons = []\n",
+    "for axon in all_axons:\n",
+    "    axon_hotkey = axon.hotkey\n",
+    "    if axon_hotkey not in metagraph.hotkeys:\n",
+    "        continue\n",
+    "    axon_uid = metagraph.hotkeys.index(axon_hotkey)\n",
+    "    if metagraph.validator_permit[axon_uid] and axon.ip != \"0.0.0.0\":\n",
+    "        all_validator_axons.append(axon)\n",
+    "\n",
+    "wallet = bt.wallet(name=wallet_name, hotkey=wallet_hotkey)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inner method to send request to a single axon\n",
+    "async def send_request_to_axon(axon: bt.AxonInfo):\n",
+    "    url = f\"http://{axon.ip}:{axon.port}/submit\"  # Update with the correct URL endpoint\n",
+    "    request_body_bytes, request_headers = create_request(\n",
+    "        data=data,\n",
+    "        sender_keypair=wallet.hotkey,\n",
+    "        receiver_hotkey=axon.hotkey\n",
+    "    )\n",
+    "\n",
+    "    try:\n",
+    "        async with aiohttp.ClientSession() as session:\n",
+    "            async with session.post(url, json=data, headers=request_headers) as response:\n",
+    "                if response.status == 200:\n",
+    "                    return {'axon': axon.hotkey, 'status': response.status, 'response': await response.json()}\n",
+    "                else:\n",
+    "                    error_message = await response.text()  # Capture response message for error details\n",
+    "                    return {'axon': axon.hotkey, 'status': response.status, 'error': error_message}\n",
+    "    except Exception as e:\n",
+    "        return {'axon': axon.hotkey, 'status': 'error', 'error': str(e)}\n",
+    "    \n",
+    "def create_request(\n",
+    "    data: dict[str, Any],\n",
+    "    sender_keypair: bt.Keypair,\n",
+    "    receiver_hotkey: Optional[str] = None\n",
+    ") -> tuple[bytes, dict[str, str]]:\n",
+    "    \"\"\"\n",
+    "    Create signed request with Epistula V2 protocol.\n",
+    "    Returns (body_bytes, headers)\n",
+    "    \"\"\"\n",
+    "    # Convert data to bytes\n",
+    "    body_bytes = json.dumps(data).encode(\"utf-8\")\n",
+    "    \n",
+    "    # Generate timestamp and UUID\n",
+    "    timestamp = round(time.time() * 1000)\n",
+    "    timestamp_interval = ceil(timestamp / 1e4) * 1e4\n",
+    "    uuid_str = str(uuid4())\n",
+    "    \n",
+    "    # Create base headers\n",
+    "    headers = {\n",
+    "        \"Epistula-Version\": \"2\",\n",
+    "        \"Epistula-Timestamp\": str(timestamp),\n",
+    "        \"Epistula-Uuid\": uuid_str,\n",
+    "        \"Epistula-Signed-By\": sender_keypair.ss58_address,\n",
+    "        \"Epistula-Request-Signature\": \"0x\" + sender_keypair.sign(\n",
+    "            f\"{sha256(body_bytes).hexdigest()}.{uuid_str}.{timestamp}.{receiver_hotkey or ''}\"\n",
+    "        ).hex(),\n",
+    "    }\n",
+    "    \n",
+    "    # Add receiver-specific headers if signed for someone\n",
+    "    if receiver_hotkey:\n",
+    "        headers[\"Epistula-Signed-For\"] = receiver_hotkey\n",
+    "        headers[\"Epistula-Secret-Signature-0\"] = (\n",
+    "            \"0x\" + sender_keypair.sign(str(timestamp_interval - 1) + \".\" + receiver_hotkey).hex()\n",
+    "        )\n",
+    "        headers[\"Epistula-Secret-Signature-1\"] = (\n",
+    "            \"0x\" + sender_keypair.sign(str(timestamp_interval) + \".\" + receiver_hotkey).hex()\n",
+    "        )\n",
+    "        headers[\"Epistula-Secret-Signature-2\"] = (\n",
+    "            \"0x\" + sender_keypair.sign(str(timestamp_interval + 1) + \".\" + receiver_hotkey).hex()\n",
+    "        )\n",
+    "    \n",
+    "    return body_bytes, headers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Send requests concurrently\n",
+    "tasks = [send_request_to_axon(axon) for axon in all_validator_axons]\n",
+    "responses = await asyncio.gather(*tasks, return_exceptions=True)\n",
+    "\n",
+    "for response in responses:\n",
+    "    if isinstance(response, Exception):\n",
+    "        print(f\"Exception occurred: {response}\")\n",
+    "    else:\n",
+    "        if \"error\" in response:\n",
+    "            print(f\"Error while sending to axon {response['axon']}: {response['error']}\")\n",
+    "        else:\n",
+    "            print(f\"Successfully submitted to axon {response['axon']} with status {response['status']}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv_2",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/neurons/miner/main.py
+++ b/neurons/miner/main.py
@@ -1,10 +1,19 @@
 import asyncio
 
+import aiohttp
 import bittensor as bt
 
+from nuance.models import PlatformType
 from nuance.utils.logging import logger
-from nuance.utils.bittensor_utils import get_subtensor, get_wallet, get_metagraph
+from nuance.utils.bittensor_utils import (
+    get_subtensor,
+    get_wallet,
+    get_metagraph,
+    get_axons,
+)
+from nuance.utils.epistula import create_request
 from nuance.settings import settings
+
 
 class Miner:
     def __init__(self):
@@ -12,14 +21,13 @@ class Miner:
         self.subtensor: bt.AsyncSubtensor = None  # Will be initialized later
         self.wallet: bt.Wallet = None  # Will be initialized later
         self.metagraph: bt.Metagraph = None  # Will be initialized later
-        
 
     async def initialize(self):
         # Initialize bittensor objects
         self.subtensor = await get_subtensor()
         self.wallet = await get_wallet()
         self.metagraph = await get_metagraph()
-        
+
         # Check if miner is registered to chain
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
             logger.error(
@@ -29,23 +37,97 @@ class Miner:
         else:
             self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
             logger.info(f"Running miner on uid: {self.uid}")
-            
+
+    async def submit(
+        self,
+        platform: PlatformType,
+        verification_post_id: str,
+        account_id: str = "",
+        username: str = "",
+        post_id: str = "",
+        interaction_id: str = "",
+    ):
+        """Submit data to validators 's submission servers"""
+        assert account_id or username, "Must provide either account_id or username"
+        assert post_id or (not interaction_id), "Interaction ID requires a post ID"
+
+        data = {
+            "platform": platform,
+            "account_id": account_id,
+            "username": username,
+            "verification_post_id": verification_post_id,
+            "post_id": post_id,
+            "interaction_id": interaction_id,
+        }
+
+        all_axons = await get_axons()
+        all_validator_axons = []
+        for axon in all_axons:
+            axon_hotkey = axon.hotkey
+            if axon_hotkey not in self.metagraph.hotkeys:
+                continue
+            axon_uid = self.metagraph.hotkeys.index(axon_hotkey)
+            if self.metagraph.validator_permit[axon_uid] and axon.ip != "0.0.0.0":
+                all_validator_axons.append(axon)
+
+        # Inner method to send request to a single axon
+        async def send_request_to_axon(axon: bt.AxonInfo):
+            url = f"http://{axon.ip}:{axon.port}/submit"  # Update with the correct URL endpoint
+            request_body_bytes, request_headers = create_request(
+                data=data,
+                sender_keypair=self.wallet.hotkey,
+                receiver_hotkey=axon.hotkey
+            )
+
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, json=data, headers=request_headers) as response:
+                        if response.status == 200:
+                            return {'axon': axon.hotkey, 'status': response.status, 'response': await response.json()}
+                        else:
+                            error_message = await response.text()  # Capture response message for error details
+                            return {'axon': axon.hotkey, 'status': response.status, 'error': error_message}
+            except Exception as e:
+                return {'axon': axon.hotkey, 'status': 'error', 'error': str(e)}
+
+        # Send requests concurrently
+        tasks = [send_request_to_axon(axon) for axon in all_validator_axons]
+        responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for response in responses:
+            if isinstance(response, Exception):
+                logger.error(f"Exception occurred: {response}")
+            else:
+                if "error" in response:
+                    logger.error(f"Error while sending to axon {response['axon']}: {response['error']}")
+                else:
+                    logger.info(f"Successfully submitted to axon {response['axon']} with status {response['status']}")
+
+
     async def run(self):
         "Miner input X account username, verification post id and commit to the chain"
-        logger.info("📢 Make sure you have already created a verification post on X before proceeding. 📝")
+        logger.info(
+            "📢 Make sure you have already created a verification post on X before proceeding. 📝"
+        )
         x_account_username = input("Enter your X account username: ")
         verification_post_id = input("Enter your verification post id: ")
         try:
             commit_data = f"{x_account_username}@{verification_post_id}"
-            await self.subtensor.commit(wallet=self.wallet, netuid=settings.NETUID, data=commit_data)            
-            logger.info(f"🎉 \033[92mYou have committed X account with username: {x_account_username} with verification post id: {verification_post_id} to the chain\033[0m 🚀")
+            await self.subtensor.commit(
+                wallet=self.wallet, netuid=settings.NETUID, data=commit_data
+            )
+            logger.info(
+                f"🎉 \033[92mYou have committed X account with username: {x_account_username} with verification post id: {verification_post_id} to the chain\033[0m 🚀"
+            )
         except Exception as e:
             logger.error(f"Error committing to chain: {e}")
-            
+
+
 async def main():
     miner = Miner()
     await miner.initialize()
     await miner.run()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/neurons/validator/api_server/app.py
+++ b/neurons/validator/api_server/app.py
@@ -1,8 +1,6 @@
-# neurons/validator/api_server.py
+# neurons/validator/api_server/app.py
 import asyncio
 import datetime
-import math
-import traceback
 from typing import Annotated, Awaitable, Callable
 
 import bittensor as bt
@@ -428,6 +426,7 @@ async def get_recent_posts(
     skip: int = 0,
     limit: int = 20,
     min_interactions: int = 1,
+    only_scored: bool = True,
 ):
     """
     Get recent posts from a specific platform created after the cutoff date.
@@ -441,6 +440,7 @@ async def get_recent_posts(
     - skip: Number of posts to skip (for pagination)
     - limit: Maximum number of posts to return
     - min_interactions: Minimum number of interactions required (default 1 to only reutnr posts with verified interactions)
+    - only_scored: Whether to filter posts by score (default True)
     """
     logger.info(
         f"Getting recent posts for platform: {platform_type}, cutoff: {cutoff_date}, min_interactions: {min_interactions}"
@@ -492,6 +492,17 @@ async def get_recent_posts(
             # Skip posts with fewer interactions than required
             if interaction_count < min_interactions:
                 continue
+
+            if only_scored:
+                skip_post = False
+                for interaction in interactions:
+                    if interaction.processing_status != models.ProcessingStatus.ACCEPTED:
+                        logger.debug(f"Interaction {interaction.interaction_id} is not accepted, skipping post {post.post_id}")
+                        skip_post = True
+                        break
+
+                if skip_post:
+                    continue
 
             result_posts.append(post)
 

--- a/neurons/validator/api_server/dependencies.py
+++ b/neurons/validator/api_server/dependencies.py
@@ -5,7 +5,7 @@ from typing import Callable, Awaitable
 from nuance.database.engine import get_db_session
 from nuance.database import PostRepository, InteractionRepository, SocialAccountRepository, NodeRepository
 from nuance.processing.nuance_check import NuanceChecker
-
+from nuance.constitution import constitution_store
 
 from nuance.processing.llm import query_llm
 # Dependency for database repositories
@@ -28,7 +28,7 @@ def get_nuance_checker() -> Callable[[str], Awaitable[bool]]:
     
     async def nuance_checker(content: str) -> bool:
         # Get the nuance prompt
-        nuance_prompt = await nuance_checker_processor.get_nuance_prompt()
+        nuance_prompt = await constitution_store.get_nuance_prompt()
         
         # Format the prompt with the post content
         prompt_nuance = nuance_prompt.format(tweet_text=content)

--- a/neurons/validator/scoring.py
+++ b/neurons/validator/scoring.py
@@ -54,7 +54,7 @@ class ScoreCalculator:
         # Base type weights
         type_weights = {
             models.InteractionType.REPLY: 1.0,
-            models.InteractionType.QUOTE: 3.0,
+            models.InteractionType.QUOTE: 6.0,
         }
 
         base_score = type_weights.get(interaction.interaction_type, 0.5) * interaction_base_score

--- a/neurons/validator/submission_server/app.py
+++ b/neurons/validator/submission_server/app.py
@@ -1,0 +1,225 @@
+# neurons/validator/submission_server/app.py
+import asyncio
+import json
+import time
+from contextlib import asynccontextmanager
+from typing import Annotated
+
+import bittensor as bt
+from fastapi import BackgroundTasks, Depends, FastAPI
+
+from nuance.utils.bittensor_utils import get_metagraph, get_wallet, is_validator
+from nuance.utils.logging import logger
+
+from .dependencies import create_verified_dependency, create_gossip_verified_dependency
+from .gossip import GossipHandler
+from .models import SubmissionData
+from .rate_limiter import RateLimiter
+
+
+def create_submission_app(
+    submission_queue: asyncio.Queue,
+) -> FastAPI:
+    """
+    Create FastAPI app for content submission.
+
+    Args:
+        submission_queue: Queue to push valid submissions to
+
+    Returns:
+        FastAPI application instance
+    """
+
+    # Initialize components
+    rate_limiter = RateLimiter()
+    gossip_handler = GossipHandler()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """Manage app lifecycle"""
+        # Start background tasks
+        cleanup_task = asyncio.create_task(rate_limiter.periodic_cleanup())
+        gossip_cleanup_task = asyncio.create_task(gossip_handler.periodic_cleanup())
+
+        logger.info("Submission server started!")
+
+        yield
+
+        # Shutdown
+        cleanup_task.cancel()
+        gossip_cleanup_task.cancel()
+
+        try:
+            await cleanup_task
+            await gossip_cleanup_task
+        except asyncio.CancelledError:
+            pass
+
+        logger.info("Submission server shutdown complete@")
+
+    # Create app
+    app = FastAPI(title="Nuance Submission Server", lifespan=lifespan)
+
+    @app.post("/submit")
+    async def submit_content(
+        verified_submission: Annotated[
+            tuple[SubmissionData, dict],
+            Depends(create_verified_dependency(data_model=SubmissionData)),
+        ],
+        metagraph: Annotated[bt.Metagraph, Depends(get_metagraph)],
+        background_tasks: BackgroundTasks,
+    ):
+        submission_data, headers = verified_submission
+        uuid = headers.get("Epistula-Uuid") or headers.get("Epistula-Uuid".lower())
+        sender_hotkey = headers.get("Epistula-Signed-By") or headers.get("Epistula-Signed-By".lower())
+        sender_uid = metagraph.hotkeys.index(sender_hotkey)
+
+        if gossip_handler.has_seen_uuid(uuid):
+            return {"status": "already_processed"}
+
+        # Check rate limit
+        alpha_stake = metagraph.alpha_stake[sender_uid]
+        if not await is_validator(sender_hotkey, metagraph):
+            allowed, message, _ = await rate_limiter.check_and_update(
+                sender_hotkey, alpha_stake
+            )
+            if not allowed:
+                return {"status": "rate_limited", "message": message}
+
+        # Mark UUID as seen
+        await gossip_handler.mark_uuid_seen(uuid)
+
+        # Queue submission
+        background_tasks.add_task(
+            queue_submission,
+            submission_data,
+            sender_hotkey,
+            uuid,
+            submission_queue,
+            from_gossip=False,
+        )
+
+        # Gossip to other validators in background
+        original_body = submission_data.model_dump()
+        original_body_bytes = json.dumps(original_body).encode()
+        background_tasks.add_task(
+            gossip_handler.broadcast_submission,
+            original_body_bytes,
+            "SubmissionData",
+            headers,
+        )
+
+        return {"status": "accepted", "message": "Submission queued for processing"}
+
+    @app.post("/gossip")
+    async def receive_gossip(
+        verified_submission: Annotated[
+            tuple[SubmissionData, dict], Depends(create_gossip_verified_dependency())
+        ],
+        background_tasks: BackgroundTasks,
+    ):
+        """
+        Receive gossip from other validators.
+
+        Only accepts requests from validators with sufficient stake.
+        """
+        submission_data, headers = verified_submission
+        uuid = headers.get("Epistula-Uuid".lower())
+        sender_hotkey = headers.get("Epistula-Signed-By".lower())
+        
+        if not uuid:
+            logger.warning("Gossip missing UUID")
+            return {"status": "invalid"}
+
+        if gossip_handler.has_seen_uuid(uuid):
+            return {"status": "already_processed"}
+
+        await gossip_handler.mark_uuid_seen(uuid)
+
+        # Optional: validate expected type if required
+        if not isinstance(submission_data, SubmissionData):
+            logger.warning("Received unsupported submission type")
+            return {"status": "invalid_model"}
+
+        # Queue submission
+        background_tasks.add_task(
+            queue_submission,
+            submission_data,
+            sender_hotkey,
+            uuid,
+            submission_queue,
+            from_gossip=True,
+        )
+
+        return {"status": "received"}
+
+    @app.get("/health")
+    async def health():
+        """Health check endpoint"""
+        return {
+            "status": "healthy",
+            "validator": (await get_wallet()).hotkey.ss58_address,
+            "queue_size": submission_queue.qsize(),
+            "rate_limiter_entries": len(rate_limiter.submissions),
+            "seen_uuids": len(gossip_handler.seen_uuids),
+        }
+
+    @app.get("/rate_limit/{hotkey}")
+    async def check_rate_limit(
+        hotkey: str,
+        metagraph: Annotated[bt.Metagraph, Depends(get_metagraph)],
+    ):
+        """Check rate limit status for a miner"""
+        if hotkey not in metagraph.hotkeys:
+            return {
+                "hotkey": hotkey,
+                "alpha_stake": None,
+                "is_validator": None,
+                "usage": None,
+            }
+
+        uid = metagraph.hotkeys.index(hotkey)
+        alpha_stake = metagraph.alpha_stake[uid]
+        usage = await rate_limiter.get_usage(hotkey, alpha_stake)
+
+        return {
+            "hotkey": hotkey,
+            "alpha_stake": alpha_stake,
+            "is_validator": await is_validator(hotkey, metagraph),
+            "usage": usage,
+        }
+
+    return app
+
+
+async def queue_submission(
+    submission_data: SubmissionData,
+    sender_hotkey: str,
+    uuid: str,
+    submission_queue: asyncio.Queue,
+    from_gossip: bool = False,
+):
+    """Queue submission for processing."""
+    try:
+        await submission_queue.put(
+            {
+                "hotkey": sender_hotkey,
+                "platform": submission_data.platform.value,
+                "account_id": submission_data.account_id,
+                "verification_post_id": submission_data.verification_post_id,
+                "post_id": submission_data.post_id,
+                "interaction_id": submission_data.interaction_id,
+                "uuid": uuid,
+                "received_at": int(time.time()),
+                "from_gossip": from_gossip,
+            }
+        )
+
+        source = "gossip" if from_gossip else "direct"
+        logger.info(
+            f"Queued {source} submission from {sender_hotkey} "
+            f"(post: {submission_data.post_id or 'none'}, "
+            f"interaction: {submission_data.interaction_id or 'none'})"
+        )
+    except Exception as e:
+        logger.error(f"Error queueing submission from {sender_hotkey}: {e}")

--- a/neurons/validator/submission_server/dependencies.py
+++ b/neurons/validator/submission_server/dependencies.py
@@ -1,0 +1,147 @@
+# neurons/validator/submission_server/dependencies.py
+import json
+from typing import Awaitable, TypeVar, Type, Callable, Optional
+
+from fastapi import Request, HTTPException
+from pydantic import BaseModel
+
+from nuance.utils.epistula import verify_request
+from nuance.utils.bittensor_utils import get_metagraph, get_wallet, is_validator
+from nuance.utils.logging import logger
+
+from .models import GossipData, MODEL_REGISTRY
+
+
+# Generic type for any Pydantic model
+T = TypeVar('T', dict, BaseModel)
+
+
+def create_verified_dependency(
+    data_model: Type[T],
+    require_validator: bool = False,
+    expected_receiver: Optional[str] = None
+) -> Callable[[Request], Awaitable[tuple[T, dict]]]:
+    """
+    Factory to create a dependency that verifies Epistula signatures 
+    and returns parsed data.
+    
+    Args:
+        data_model: The Pydantic model to parse the body into, can also be a dict to skip parsing
+        metagraph: Bittensor metagraph for verification
+        require_validator: If True, only accept requests from validators
+        expected_receiver: Can explicitly set to blank string to avoid receiver checking
+        
+    Returns:
+        Dependency function for FastAPI
+    """
+    async def verify_and_parse(request: Request) -> tuple[T, dict]:
+        """
+        Verify Epistula signature and parse body.
+        
+        Returns:
+            Tuple of (parsed_data, headers)
+        """
+        nonlocal expected_receiver
+
+        metagraph = await get_metagraph()
+        if expected_receiver is None:
+            # Default to validator 's hotkey, can explicitly set to blank string to avoid
+            self_hotkey = (await get_wallet()).hotkey.ss58_address
+            expected_receiver = self_hotkey
+
+        try:
+            body = await request.body()
+            headers = dict(request.headers)
+            
+            # Verify signature
+            is_valid, error, sender_hotkey = verify_request(
+                headers=headers,
+                body=body,
+                metagraph=metagraph,
+                expected_receiver=expected_receiver
+            )
+            
+            if not is_valid:
+                raise HTTPException(403, f"Invalid request: {error}")
+            
+            # Check if validator required
+            if require_validator and not is_validator(sender_hotkey, metagraph):
+                raise HTTPException(403, "Only validators can access this endpoint")
+            
+            # Check UUID
+            uuid = headers.get("Epistula-Uuid") or headers.get("Epistula-Uuid".lower())
+            if not uuid:
+                raise HTTPException(400, "Missing Epistula-Uuid header")
+            
+            # Parse body
+            data = json.loads(body)
+            if data_model is dict:
+                parsed_data = data  # skip parsing
+            elif issubclass(data_model, BaseModel):
+                parsed_data = data_model(**data)
+            else:
+                raise HTTPException(500, "Invalid data model type")
+            
+            return parsed_data, headers
+            
+        except HTTPException:
+            raise
+        except json.JSONDecodeError:
+            raise HTTPException(400, "Invalid JSON body")
+        except Exception as e:
+            logger.error(f"Error in verified dependency: {e}")
+            raise HTTPException(400, f"Invalid data: {str(e)}")
+    
+    return verify_and_parse
+
+
+def create_gossip_verified_dependency() -> Callable:
+    """
+    General gossip dependency that:
+    - Verifies outer GossipData request
+    - Extracts model name
+    - Parses nested body with correct model
+    """
+
+    async def verify_gossip(request: Request) -> tuple[T, dict]:
+        metagraph = await get_metagraph()
+
+        outer_verifier = create_verified_dependency(GossipData, require_validator=True)
+        gossip_data: GossipData
+        gossip_data, gossip_headers = await outer_verifier(request)
+
+        model_name = gossip_data.original_body_model
+        if model_name not in MODEL_REGISTRY:
+            raise HTTPException(400, f"Unsupported model: {model_name}")
+
+        inner_model = MODEL_REGISTRY[model_name]
+        # Since we currently do not re-broadcast, the expected receiver of the inner message is the one who broadcasted
+        # Prepare inner data
+        inner_body = bytes.fromhex(gossip_data.original_body_hex)
+        inner_headers = gossip_data.original_headers
+        expected_receiver = gossip_headers.get("Epistula-Signed-By") or gossip_headers.get("Epistula-Signed-By".lower())
+        
+        is_valid, error, sender_hotkey = verify_request(
+            headers=inner_headers,
+            body=inner_body,
+            metagraph=metagraph,
+            expected_receiver=expected_receiver,
+        )
+        if not is_valid:
+            raise HTTPException(403, f"Invalid inner gossip request: {error}")
+
+        # Parse
+        try:
+            data = json.loads(inner_body)
+            if inner_model is dict:
+                parsed = data
+            elif issubclass(inner_model, BaseModel):
+                parsed = inner_model(**data)
+            else:
+                raise HTTPException(500, "Invalid inner model type")
+        except json.JSONDecodeError:
+            raise HTTPException(400, "Invalid JSON in inner request")
+
+        return parsed, inner_headers
+
+    return verify_gossip

--- a/neurons/validator/submission_server/gossip.py
+++ b/neurons/validator/submission_server/gossip.py
@@ -1,0 +1,243 @@
+# neurons/validator/submission_server/gossip.py
+import asyncio
+from datetime import datetime, timedelta
+
+import aiohttp
+import bittensor as bt
+
+from nuance.utils.logging import logger
+from nuance.utils.bittensor_utils import get_wallet, get_metagraph, get_axons
+from nuance.utils.epistula import create_request
+
+from .models import GossipData
+
+
+class GossipHandler:
+    """
+    Handles gossip between validators.
+    
+    Prevents loops by tracking UUIDs and forwards submissions
+    to other validators for redundancy.
+    """
+    
+    def __init__(
+        self,
+        uuid_ttl_hours: int = 24,
+        gossip_timeout: int = 5
+    ):
+        self.uuid_ttl_hours = uuid_ttl_hours
+        self.gossip_timeout = gossip_timeout
+        
+        # Track seen UUIDs with timestamps
+        self.seen_uuids: dict[str, datetime] = {}
+        self._lock = asyncio.Lock()
+        
+        # Track gossip statistics
+        self.gossip_stats = {
+            "total_sent": 0,
+            "total_success": 0,
+            "total_failed": 0
+        }
+    
+    def has_seen_uuid(self, uuid: str) -> bool:
+        """Check if UUID has been seen (thread-safe)"""
+        return uuid in self.seen_uuids
+    
+    async def mark_uuid_seen(self, uuid: str):
+        """Mark UUID as seen with current timestamp"""
+        async with self._lock:
+            self.seen_uuids[uuid] = datetime.now()
+    
+    async def get_validator_axons(self) -> list[bt.AxonInfo]:
+        """
+        Get list of validator axons from metagraph.
+        
+        Returns:
+            List of AxonInfo for validators
+        """
+        validator_axons = []
+        metagraph = await get_metagraph()
+        self_hotkey = (await get_wallet()).hotkey.ss58_address
+        all_axons = await get_axons()
+
+        for axon in all_axons:
+            hotkey = axon.hotkey
+            if hotkey not in metagraph.hotkeys:
+                continue
+
+            # Skip self
+            if hotkey == self_hotkey:
+                continue
+
+            uid = metagraph.hotkeys.index(hotkey)
+            
+            # Check if validator permitted
+            if metagraph.validator_permit[uid]:
+                # Skip if no IP
+                if not axon.ip or axon.ip == "0.0.0.0":
+                    logger.debug(f"Skipping axon with invalid IP: {axon}")
+                    continue
+
+                validator_axons.append(axon)
+        
+        return validator_axons
+    
+    async def broadcast_submission(
+        self, 
+        original_body_bytes: bytes,
+        original_body_model: str, 
+        original_headers: dict[str, str]
+    ):
+        """
+        Broadcast submission to all other validators.
+        
+        Args:
+            original_body: Original request body as bytes
+            original_headers: Original Epistula headers
+        """
+        validator_axons = await self.get_validator_axons()
+        
+        if not validator_axons:
+            logger.info("No other validators to gossip to")
+            return
+        
+        logger.info(f"Broadcasting to {len(validator_axons)} validators")
+        
+        # Prepare gossip data
+        gossip_data = GossipData(
+            original_body_hex=original_body_bytes.hex(),
+            original_body_model=original_body_model,
+            original_headers=original_headers
+        ).model_dump()
+        
+        # Send to all validators concurrently
+        tasks = []
+        async with aiohttp.ClientSession() as session:
+            for axon in validator_axons:
+                url = f"http://{axon.ip}:{axon.port}/gossip"
+                task = self._send_gossip(session, url, gossip_data, axon.hotkey)
+                tasks.append((axon.hotkey, task))
+            
+            # Wait for all to complete
+            results = []
+            for hotkey, task in tasks:
+                try:
+                    success = await task
+                    results.append((hotkey, success))
+                except Exception as e:
+                    logger.debug(f"Gossip to {hotkey} failed with exception: {e}")
+                    results.append((hotkey, False))
+        
+        # Update statistics
+        successes = sum(1 for _, success in results if success)
+        self.gossip_stats["total_sent"] += len(validator_axons)
+        self.gossip_stats["total_success"] += successes
+        self.gossip_stats["total_failed"] += (len(validator_axons) - successes)
+        
+        # Log results
+        logger.info(f"Gossip broadcast: {successes}/{len(validator_axons)} successful")
+        
+        # Log failures for debugging
+        for hotkey, success in results:
+            if not success:
+                logger.debug(f"Failed to gossip to {hotkey}")
+    
+    async def _send_gossip(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        gossip_data: dict,
+        receiver_hotkey: str
+    ) -> bool:
+        """
+        Send gossip to a single validator.
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            # Create signed request with Epistula V2
+            request_body_bytes, request_headers = create_request(
+                data=gossip_data,
+                sender_keypair=(await get_wallet()).hotkey,
+                receiver_hotkey=receiver_hotkey
+            )
+            
+            # Send request
+            async with session.post(
+                url,
+                json=gossip_data,
+                headers=request_headers,
+                timeout=aiohttp.ClientTimeout(total=self.gossip_timeout)
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    status = data.get("status", "unknown")
+                    
+                    # Log if already processed (normal behavior)
+                    if status == "already_processed":
+                        logger.debug(f"Gossip to {url}: already processed")
+                    
+                    return True
+                else:
+                    text = await response.text()
+                    logger.debug(f"Gossip to {url} failed: HTTP {response.status} - {text}")
+                    return False
+                    
+        except asyncio.TimeoutError:
+            logger.debug(f"Gossip to {url} timed out")
+            return False
+        except aiohttp.ClientError as e:
+            logger.debug(f"Gossip to {url} connection error: {e}")
+            return False
+        except Exception as e:
+            logger.debug(f"Gossip to {url} unexpected error: {e}")
+            return False
+    
+    async def periodic_cleanup(self):
+        """Clean old UUIDs periodically to prevent memory growth"""
+        while True:
+            try:
+                # Run cleanup every hour
+                await asyncio.sleep(3600)
+                await self._cleanup_old_uuids()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in gossip cleanup: {e}")
+    
+    async def _cleanup_old_uuids(self):
+        """Remove UUIDs older than TTL"""
+        async with self._lock:
+            now = datetime.now()
+            cutoff = now - timedelta(hours=self.uuid_ttl_hours)
+            
+            # Find old UUIDs
+            old_uuids = [
+                uuid for uuid, timestamp in self.seen_uuids.items()
+                if timestamp < cutoff
+            ]
+            
+            # Remove them
+            for uuid in old_uuids:
+                del self.seen_uuids[uuid]
+            
+            if old_uuids:
+                logger.info(
+                    f"Gossip cleanup: removed {len(old_uuids)} old UUIDs, "
+                    f"{len(self.seen_uuids)} remaining"
+                )
+                
+            # Log statistics
+            logger.info(
+                f"Gossip stats - Total: {self.gossip_stats['total_sent']}, "
+                f"Success: {self.gossip_stats['total_success']}, "
+                f"Failed: {self.gossip_stats['total_failed']}"
+            )
+    
+    def get_stats(self) -> dict:
+        """Get gossip statistics"""
+        return {
+            "seen_uuids": len(self.seen_uuids),
+            "gossip_stats": self.gossip_stats.copy()
+        }

--- a/neurons/validator/submission_server/models.py
+++ b/neurons/validator/submission_server/models.py
@@ -1,0 +1,40 @@
+# neurons/validator/submission_server/models.py
+import time
+from pydantic import BaseModel, Field, model_validator
+from nuance.models import PlatformType
+
+
+class SubmissionData(BaseModel):
+    """Content submission payload from miners - one item per request"""
+    platform: PlatformType
+    account_id: str = ""
+    username: str = ""
+    verification_post_id: str
+    post_id: str = ""
+    interaction_id: str = ""
+    
+    @model_validator(mode='after')
+    def validate_submission_data(self):
+        """Validate cross-field relationships"""
+        
+        # Must provide either account_id or username
+        if not self.username and not self.account_id:
+            raise ValueError("Must provide either account_id or username")
+        
+        # Interaction ID requires a post ID
+        if self.interaction_id and not self.post_id:
+            raise ValueError("Interaction ID requires a post ID")
+        
+        return self
+
+class GossipData(BaseModel):
+    """Gossip payload between validators"""
+    original_body_model: str  # One of the model in neurons/validator/submission_server/models.py
+    original_body_hex: str
+    original_headers: dict[str, str]
+    forwarded_at: int = Field(default_factory=lambda: int(time.time() * 1000))
+
+
+MODEL_REGISTRY = {
+    "SubmissionData": SubmissionData,
+}

--- a/neurons/validator/submission_server/rate_limiter.py
+++ b/neurons/validator/submission_server/rate_limiter.py
@@ -1,0 +1,132 @@
+# neurons/validator/submission_server/rate_limiter.py
+"""Stake-based rate limiting for submission server"""
+import asyncio
+import math
+from collections import defaultdict, deque
+from datetime import datetime, timedelta
+from typing import  Deque
+
+from nuance.utils.logging import logger
+
+
+class RateLimiter:
+    """(Alpha) Stake-based rate limiter"""
+    
+    def __init__(
+        self,
+        base_limit_per_hour: int = 10,  # Base limit for minimal stake
+        max_limit_per_hour: int = 100,  # Max limit for high stake
+        cleanup_interval_seconds: int = 3600
+    ):
+        self.base_limit = base_limit_per_hour
+        self.max_limit = max_limit_per_hour
+        self.cleanup_interval = cleanup_interval_seconds
+        
+        # Track submissions by hotkey
+        self.submissions: dict[str, Deque[datetime]] = defaultdict(deque)
+        self._lock = asyncio.Lock()
+    
+    def calculate_rate_limit(self, stake: float) -> int:
+        """
+        Calculate rate limit based on stake.
+        Higher stake = higher limit.
+        
+        Examples:
+        - 0 Alpha = 10 submissions/hour
+        - 100 Alpha = 50 submissions/hour  
+        - 1000 Alpha = 200 submissions/hour
+        - 10000+ Alpha = 1000 submissions/hour (max)
+        """
+        if stake <= 0:
+            return self.base_limit
+            
+        # Logarithmic scaling: limit = base + (max-base) * log10(stake+1) / log10(10000)
+        # Normalize stake to 0-1 range using log scale
+        normalized = math.log10(stake + 1) / math.log10(10000)
+        normalized = min(normalized, 1.0)  # Cap at 1
+        
+        # Calculate limit
+        limit = int(self.base_limit + (self.max_limit - self.base_limit) * normalized)
+        
+        return limit
+    
+    async def check_and_update(self, hotkey: str, stake: float) -> tuple[bool, str, int]:
+        """
+        Check if hotkey can submit and update counter.
+        Returns (allowed, message, current_limit)
+        """
+        # Calculate this miner's limit
+        rate_limit = self.calculate_rate_limit(stake)
+        
+        async with self._lock:
+            now = datetime.now()
+            hour_ago = now - timedelta(hours=1)
+            
+            # Get submissions for this hotkey
+            hotkey_submissions = self.submissions[hotkey]
+            
+            # Remove old submissions
+            while hotkey_submissions and hotkey_submissions[0] < hour_ago:
+                hotkey_submissions.popleft()
+            
+            # Check limit
+            current_count = len(hotkey_submissions)
+            if current_count >= rate_limit:
+                return False, f"Rate limit exceeded: {current_count}/{rate_limit} per hour (stake: {stake:.1f} Alpha)", rate_limit
+            
+            # Add new submission
+            hotkey_submissions.append(now)
+            return True, f"OK: {current_count + 1}/{rate_limit} per hour", rate_limit
+    
+    async def get_usage(self, hotkey: str, stake: float) -> dict[str, int]:
+        """Get current usage stats for a hotkey"""
+        rate_limit = self.calculate_rate_limit(stake)
+        
+        async with self._lock:
+            now = datetime.now()
+            hour_ago = now - timedelta(hours=1)
+            
+            # Count recent submissions
+            hotkey_submissions = self.submissions[hotkey]
+            current_count = sum(1 for ts in hotkey_submissions if ts > hour_ago)
+            
+            return {
+                "current_count": current_count,
+                "rate_limit": rate_limit,
+                "remaining": max(0, rate_limit - current_count)
+            }
+    
+    async def periodic_cleanup(self):
+        """Periodically clean up old entries"""
+        while True:
+            try:
+                await asyncio.sleep(self.cleanup_interval)
+                await self._cleanup()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in rate limiter cleanup: {e}")
+    
+    async def _cleanup(self):
+        """Remove old entries to free memory"""
+        async with self._lock:
+            now = datetime.now()
+            hour_ago = now - timedelta(hours=1)
+            
+            # Clean each hotkey's submissions
+            empty_keys = []
+            for hotkey, submissions in self.submissions.items():
+                # Remove old submissions
+                while submissions and submissions[0] < hour_ago:
+                    submissions.popleft()
+                
+                # Mark empty keys for removal
+                if not submissions:
+                    empty_keys.append(hotkey)
+            
+            # Remove empty entries
+            for key in empty_keys:
+                del self.submissions[key]
+            
+            if empty_keys:
+                logger.info(f"Rate limiter cleanup: removed {len(empty_keys)} empty entries")

--- a/nuance/models.py
+++ b/nuance/models.py
@@ -27,7 +27,7 @@ class Commit(BaseModel):
     node_netuid: int
     platform: PlatformType
     account_id: Optional[str] = None
-    username: str
+    username: Optional[str] = None
     verification_post_id: str
 
 

--- a/nuance/settings.py
+++ b/nuance/settings.py
@@ -51,6 +51,26 @@ class Settings(BaseSettings):
         description="Echo SQL statements to stdout (defaults to debug setting if None)."
     )
 
+    # Submission server settings
+    SUBMISSION_SERVER_HOST: str = Field(
+        default="0.0.0.0",
+        description="Network interface to bind the submission server to. "
+                "Default (0.0.0.0) listens on all interfaces.",
+    )
+    SUBMISSION_SERVER_PORT: int = Field(
+        default=10000,
+        description="Internal port where the validator's submission server runs."
+    )
+    SUBMISSION_SERVER_PUBLIC_IP: str = Field(
+        default="",
+        description="REQUIRED: Public IP address for peer connections. "
+                "Must match the inbound IP in your cloud/firewall settings.",
+    )
+    SUBMISSION_SERVER_EXTERNAL_PORT: int = Field(
+        default=10000,
+        description="Public-facing port (if behind NAT/proxy). Set to `SUBMISSION_SERVER_PORT` if no port mapping exists."
+    )
+
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=True, extra="ignore"
     )

--- a/nuance/social/discovery/base.py
+++ b/nuance/social/discovery/base.py
@@ -15,6 +15,10 @@ class BaseDiscoveryStrategy(ABC, Generic[T]):
     @abstractmethod
     async def get_post(self, *args, **kwargs) -> dict:
         pass
+
+    @abstractmethod
+    async def get_interaction(self, *args, **kwargs) -> dict:
+        pass
     
     async def discover_new_posts(self, *args, **kwargs) -> list[dict]:
         pass

--- a/nuance/utils/epistula.py
+++ b/nuance/utils/epistula.py
@@ -1,0 +1,186 @@
+"""Epistula V2 protocol utilities with case-insensitive header handling"""
+import json
+import time
+from hashlib import sha256
+from uuid import uuid4
+from math import ceil
+from typing import Any, Optional
+
+import bittensor as bt
+
+ALLOWED_DELTA_MS = 8000  # 8 seconds
+
+def get_header_case_insensitive(headers: dict, key: str) -> Optional[str]:
+    """Get header value in a case-insensitive way"""
+    # Try exact match first
+    if key in headers:
+        return headers[key]
+    
+    # Try lowercase
+    key_lower = key.lower()
+    if key_lower in headers:
+        return headers[key_lower]
+    
+    # Try all variations
+    for header_key, header_value in headers.items():
+        if header_key.lower() == key_lower:
+            return header_value
+    
+    return None
+
+def create_request(
+    data: dict[str, Any],
+    sender_keypair: bt.Keypair,
+    receiver_hotkey: Optional[str] = None
+) -> tuple[bytes, dict[str, str]]:
+    """
+    Create signed request with Epistula V2 protocol.
+    Returns (body_bytes, headers)
+    """
+    # Convert data to bytes
+    body_bytes = json.dumps(data).encode("utf-8")
+    
+    # Generate timestamp and UUID
+    timestamp = round(time.time() * 1000)
+    timestamp_interval = ceil(timestamp / 1e4) * 1e4
+    uuid_str = str(uuid4())
+    
+    # Create base headers
+    headers = {
+        "Epistula-Version": "2",
+        "Epistula-Timestamp": str(timestamp),
+        "Epistula-Uuid": uuid_str,
+        "Epistula-Signed-By": sender_keypair.ss58_address,
+        "Epistula-Request-Signature": "0x" + sender_keypair.sign(
+            f"{sha256(body_bytes).hexdigest()}.{uuid_str}.{timestamp}.{receiver_hotkey or ''}"
+        ).hex(),
+    }
+    
+    # Add receiver-specific headers if signed for someone
+    if receiver_hotkey:
+        headers["Epistula-Signed-For"] = receiver_hotkey
+        headers["Epistula-Secret-Signature-0"] = (
+            "0x" + sender_keypair.sign(str(timestamp_interval - 1) + "." + receiver_hotkey).hex()
+        )
+        headers["Epistula-Secret-Signature-1"] = (
+            "0x" + sender_keypair.sign(str(timestamp_interval) + "." + receiver_hotkey).hex()
+        )
+        headers["Epistula-Secret-Signature-2"] = (
+            "0x" + sender_keypair.sign(str(timestamp_interval + 1) + "." + receiver_hotkey).hex()
+        )
+    
+    return body_bytes, headers
+
+def verify_request(
+    headers: dict[str, str],
+    body: bytes,
+    metagraph: bt.metagraph,
+    expected_receiver: Optional[str] = None
+) -> tuple[bool, Optional[str], Optional[str]]:
+    """
+    Verify request signature with Epistula V2 protocol.
+    Returns (is_valid, error_message, sender_hotkey)
+    """
+    try:
+        # Extract headers using case-insensitive lookup
+        signature = get_header_case_insensitive(headers, "Epistula-Request-Signature")
+        timestamp = get_header_case_insensitive(headers, "Epistula-Timestamp")
+        uuid_str = get_header_case_insensitive(headers, "Epistula-Uuid")
+        signed_for = get_header_case_insensitive(headers, "Epistula-Signed-For") or ""
+        signed_by = get_header_case_insensitive(headers, "Epistula-Signed-By")
+        version = get_header_case_insensitive(headers, "Epistula-Version")
+        
+        # Check version
+        if version != "2":
+            return False, f"Unsupported Epistula version: {version}", None
+        
+        # Basic validation
+        if not signature:
+            return False, "Missing signature", None
+        if not timestamp:
+            return False, "Missing timestamp", None
+        if not uuid_str:
+            return False, "Missing UUID", None
+        if not signed_by:
+            return False, "Missing sender", None
+            
+        # Convert timestamp
+        try:
+            timestamp_int = int(timestamp)
+        except Exception:
+            return False, "Invalid timestamp", None
+            
+        # Check if sender in metagraph
+        if signed_by not in metagraph.hotkeys:
+            return False, "Sender not in metagraph", None
+            
+        # Check staleness
+        now = round(time.time() * 1000)
+        if timestamp_int + ALLOWED_DELTA_MS < now:
+            return False, "Request too stale", None
+            
+        # Check expected receiver if specified
+        if expected_receiver and signed_for and signed_for != expected_receiver:
+            return False, "Request not signed for this receiver", None
+            
+        # Verify signature
+        if signature.startswith("0x"):
+            signature = signature[2:]
+            
+        keypair = bt.Keypair(ss58_address=signed_by)
+        message = f"{sha256(body).hexdigest()}.{uuid_str}.{timestamp}.{signed_for}"
+        
+        if not keypair.verify(message, bytes.fromhex(signature)):
+            return False, "Invalid signature", None
+            
+        return True, None, signed_by
+        
+    except Exception as e:
+        return False, f"Verification error: {str(e)}", None
+
+def verify_secret_signatures(
+    headers: dict[str, str],
+    receiver_keypair: bt.Keypair
+) -> bool:
+    """
+    Verify secret signatures when request is signed for a specific receiver.
+    This proves the sender knows who they're sending to.
+    """
+    try:
+        timestamp = get_header_case_insensitive(headers, "Epistula-Timestamp")
+        signed_by = get_header_case_insensitive(headers, "Epistula-Signed-By")
+        signed_for = get_header_case_insensitive(headers, "Epistula-Signed-For")
+        
+        if not all([timestamp, signed_by, signed_for]):
+            return False
+            
+        # Check if signed for us
+        if signed_for != receiver_keypair.ss58_address:
+            return False
+            
+        # Calculate timestamp interval
+        timestamp_int = int(timestamp)
+        timestamp_interval = ceil(timestamp_int / 1e4) * 1e4
+        
+        # Verify at least one secret signature
+        sender_keypair = bt.Keypair(ss58_address=signed_by)
+        
+        for i, interval_offset in enumerate([-1, 0, 1]):
+            sig_header = f"Epistula-Secret-Signature-{i}"
+            signature = get_header_case_insensitive(headers, sig_header) or ""
+            
+            if signature.startswith("0x"):
+                signature = signature[2:]
+                
+            message = f"{timestamp_interval + interval_offset}.{signed_for}"
+            
+            try:
+                if sender_keypair.verify(message, bytes.fromhex(signature)):
+                    return True
+            except Exception:
+                continue
+                
+        return False
+        
+    except Exception:
+        return False

--- a/tests/twitter_quote_to_interaction.py
+++ b/tests/twitter_quote_to_interaction.py
@@ -129,7 +129,7 @@ def test_quote_to_interaction():
         }
     }""")
 
-    interaction = _tweet_to_interaction(quote, social_account=quote["user"], interaction_type=models.InteractionType.QUOTE)
+    interaction = _tweet_to_interaction(quote, social_account=quote["user"])
     print(interaction)
 
 if __name__ == "__main__":


### PR DESCRIPTION
The goal is to create a more scalable system where miners/validators can submit posts to other validators. That way, not all validators have to search for posts by all users, but can directly be sent the submissions.

Further, this allows a single UID to have multiple handles connected to it.

Validators would receive:
- Post ID of the user opting in to a certain hotkey.
- Post ID of the engagement that should be scored.

Rule: only accept requests from registered hotkeys on the network (meaning checking signature), and have limits like 1000 per day per uid.