### PR TITLE
Update 26/08/2025

### DIFF
--- a/neurons/validator/main.py
+++ b/neurons/validator/main.py
@@ -212,12 +212,20 @@ class NuanceValidator:
                             )
 
                             # Check if verification account username appears as hashtag
-                            HASHTAG_PATTERN = re.compile(r"#([A-Za-z0-9_]{1,15})")
-                            def extract_hashtags(text: str) -> list[str]:
-                                """Extract all valid hashtags from text according to Twitter username rules and hashtag rules."""
-                                return [tag.lower() for tag in HASHTAG_PATTERN.findall(text or "")]
+                            NUANCE_PATTERN = re.compile(r"\bnuance([A-Za-z0-9_]{1,15})", flags=re.IGNORECASE)
+
+                            def extract_nuance_usernames(text: str) -> list[str]:
+                                """
+                                Extract usernames from 'NuanceUsername' markers in the text.
+                                - 'Nuance' prefix is case-insensitive.
+                                - Usernames must match Twitter's username rules.
+                                - Returned usernames are normalized to lowercase.
+                                """
+                                if not text:
+                                    return []
+                                return [match.lower() for match in NUANCE_PATTERN.findall(text)]
                             
-                            hashtags = extract_hashtags(post.content)
+                            nuance_usernames_found= extract_nuance_usernames(post.content)
                             if not account.account_username:
                                 logger.warning(
                                     f"Verified account {account.account_id} has no username set, "
@@ -225,7 +233,7 @@ class NuanceValidator:
                                 )
                                 continue
 
-                            if account.account_username.lower() not in hashtags:
+                            if account.account_username.lower() not in nuance_usernames_found:
                                 logger.warning(
                                     f"Verified account {account.account_id} cannot claim ownership "
                                     f"of post {post_id}: verification hashtag #{account.account_username} "

--- a/nuance/processing/topic_tagger.py
+++ b/nuance/processing/topic_tagger.py
@@ -56,8 +56,7 @@ class TopicTagger(Processor):
                 try:
                     is_quote_tweet = post.extra_data.get("is_quote_tweet", False)
                     quoted_user_id = post.extra_data.get("quote", {}).get("user", {}).get("id")
-                    has_keyword = "NuanceOverNoise" in post.content
-                    if is_quote_tweet and quoted_user_id == cst.NUANCE_SOCIAL_ACCOUNT_ID and has_keyword:
+                    if is_quote_tweet and quoted_user_id == cst.NUANCE_SOCIAL_ACCOUNT_ID:
                         identified_topics.append("nuance-sharing")
                 except Exception:
                     pass


### PR DESCRIPTION
- `nuance-sharing` category no longer require post content to have `NuanceOverNoise` keyword, miners only need to QRT `@NuanceSubnet`.
- Post verification with proxy account username as hashtag no longer require hashtag to strictly end the post, no hashtag needed anymore, the post just need to have `Nuance{account_username}` in its content with `account_username` being username of the account that post the verification post.